### PR TITLE
プロジェクト内の改行コードをLFに統一する

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
# 問題は？
docker内部で使うスクリプト類（gradlew, *.sh）がコンテナにマウントされるときCRLFだと死ぬ
```
juiceapp_frontend-backend-1  | exec ./gradlew: no such file or directory
```

# 解決
`.gitattribute`でLFを強制する
windows固有の`*.bat`などのみCRLFにする
https://qiita.com/Yossy_Hal/items/6fe2d14cddd6e16796d7

下記の1の方法

```
編集者 -> GitHub(LF) -> 開発者(CRLF) -> container
       |             |               |             
    自動変換          1               2
```
## 案
1a. `.gitattribute`で制御し，pull時点でCRLFに変換されないようにする
1b. clone時点でオプション`core.autocrlf=false`を指定させる
2. containerによる実行前にcrlfからlfへの置換処理を走らせる
